### PR TITLE
update to latest calico

### DIFF
--- a/scripts/calico-vxlan.yaml
+++ b/scripts/calico-vxlan.yaml
@@ -3544,7 +3544,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: calico/cni:v3.19.0
+          image: docker.io/calico/cni:v3.19.1
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -3571,7 +3571,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v3.19.0
+          image: docker.io/calico/cni:v3.19.1
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3612,7 +3612,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: calico/pod2daemon-flexvol:v3.19.0
+          image: docker.io/calico/pod2daemon-flexvol:v3.19.1
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -3623,7 +3623,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v3.19.0
+          image: docker.io/calico/node:v3.19.1
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -3831,7 +3831,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: calico-kube-controllers
-          image: calico/kube-controllers:v3.19.0
+          image: docker.io/calico/kube-controllers:v3.19.1
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS
@@ -3886,6 +3886,5 @@ spec:
 
 ---
 # Source: calico/templates/configure-canal.yaml
-
 
 


### PR DESCRIPTION
I _could_ grab the latest on every install - but let's just manually control this for a bit.  The changes are:

Bug fixes:
    * Fix issue with serviceaccount names larger than 63 characters. libcalico-go #1423 (@caseydavenport)
